### PR TITLE
Remove redundant file names from exclusion list.

### DIFF
--- a/core/swift4Action/swift4runner.py
+++ b/core/swift4Action/swift4runner.py
@@ -60,7 +60,7 @@ class Swift4Runner(ActionRunner):
         with codecs.open(DEST_SCRIPT_FILE, 'a', 'utf-8') as fp:
             os.chdir(DEST_SCRIPT_DIR)
             for file in glob.glob("*.swift"):
-                if file not in ["Package.swift", "main.swift", "_WhiskJSONUtils.swift", "_Whisk.swift"]:
+                if file not in ["Package.swift", "_Whisk.swift"]:
                     with codecs.open(file, 'r', 'utf-8') as f:
                         fp.write(f.read())
             with codecs.open(SRC_EPILOGUE_FILE, 'r', 'utf-8') as ep:


### PR DESCRIPTION
Swift files called `main.swift` are ignored when deploying files from an archive.

Here's an example of this bug. If I change the source file to another other than `main.swift` it works.

```
$ cat main.swift
func main(args: [String:Any]) -> [String:Any] {
    if let name = args["name"] as? String {
        return [ "greeting" : "Hello \(name)!" ]
    } else {
        return [ "greeting" : "Hello swif4!" ]
    }
}
$ zip action.zip main.swift
  adding: main.swift (deflated 46%)
$ bx wsk action create swift4-test --docker jamesthomas/action-swift-v4 action.zip
ok: created action swift4-test
$ bx wsk action invoke swift4-test -b
ok: invoked /_/swift4-test with id 775ec7f003c54d4b9ec7f003c5cd4b43
{
   ...
    "response": {
        "result": {
            "error": "The action failed to generate or locate a binary. See logs for details."
        },
        "status": "action developer error",
        "success": false
    },
    ...
}
$ bx wsk activation logs 775ec7f003c54d4b9ec7f003c5cd4b43
2018-01-30T16:12:49.982020071Z stdout: Compiling
2018-01-30T16:12:49.982079711Z stdout: swiftc status is 1
2018-01-30T16:12:49.982088978Z stdout: Action did not compile
2018-01-30T16:12:49.982047826Z stderr: /swift4Action/spm-build/Sources/Action/main.swift:29:25: error: use of unresolved identifier 'main'
2018-01-30T16:12:49.982107746Z stderr: _run_main(mainFunction: main)
2018-01-30T16:12:49.982114186Z stderr: ^~~~
2018-01-30T16:12:49.982123311Z stderr: Swift.min:7:13: note: did you mean 'min'?
2018-01-30T16:12:49.982129815Z stderr: public func min<T>(_ x: T, _ y: T) -> T where T : Comparable
2018-01-30T16:12:49.982136717Z stderr: ^
2018-01-30T16:12:49.982142661Z stderr: Swift.min:10:13: note: did you mean 'min'?
2018-01-30T16:12:49.982150812Z stderr: public func min<T>(_ x: T, _ y: T, _ z: T, _ rest: T...) -> T where T : Comparable
2018-01-30T16:12:49.982160464Z stderr: ^
```

This is due to the this code which ignores files with a given list of names.
https://github.com/apache/incubator-openwhisk-runtime-swift/blob/master/core/swift4Action/swift4runner.py#L63

When the Python code runs to write all source files into the `/swift4Action/spm-build/Sources/Action/main.swift` file, the `main.swift` file is ignored which causes a missing reference to the `main` function and breaks the build as seen above.

Looking at the list, I think only "Package.swift" and "_Whisk.swift" need to be in that list. `_WhiskJSONUtils.swift` doesn't exist in the project anymore for Swift 4. I don't see a reason that a source file can't be called `main.swift`. 

I've built the changes into a local container and tested it works.