### PR TITLE
Update to golang:1.15 for build (security).

### DIFF
--- a/core/swift42Action/CHANGELOG.md
+++ b/core/swift42Action/CHANGELOG.md
@@ -19,6 +19,9 @@
 
 # Apache OpenWhisk Swift 4.2 Runtime Container
 
+## 1.15.0
+  - Move from golang:1.12 to golang:1.15 to build the runtime proxy.
+
 ## 1.14.0
   - Support for __OW_ACTION_VERSION (openwhisk/4761)
 

--- a/core/swift42Action/Dockerfile
+++ b/core/swift42Action/Dockerfile
@@ -16,11 +16,11 @@
 #
 
 # build go proxy from source
-FROM golang:1.12 AS builder_source
+FROM golang:1.15 AS builder_source
 RUN env CGO_ENABLED=0 go get github.com/apache/openwhisk-runtime-go/main && mv /go/bin/main /bin/proxy
 
 # or build it from a release
-FROM golang:1.12 AS builder_release
+FROM golang:1.15 AS builder_release
 ARG GO_PROXY_RELEASE_VERSION=1.12@1.15.0
 RUN curl -sL \
   https://github.com/apache/openwhisk-runtime-go/archive/{$GO_PROXY_RELEASE_VERSION}.tar.gz\

--- a/core/swift51Action/CHANGELOG.md
+++ b/core/swift51Action/CHANGELOG.md
@@ -19,5 +19,8 @@
 
 # Apache OpenWhisk Swift 5.1 Runtime Container
 
+## 1.15.0
+  - Move from golang:1.12 to golang:1.15 to build the runtime proxy.
+
 ## 1.14.0
  - Initial Release

--- a/core/swift51Action/Dockerfile
+++ b/core/swift51Action/Dockerfile
@@ -16,11 +16,11 @@
 #
 
 # build go proxy from source
-FROM golang:1.12 AS builder_source
+FROM golang:1.15 AS builder_source
 RUN env CGO_ENABLED=0 go get github.com/apache/openwhisk-runtime-go/main && mv /go/bin/main /bin/proxy
 
 # or build it from a release
-FROM golang:1.12 AS builder_release
+FROM golang:1.15 AS builder_release
 ARG GO_PROXY_RELEASE_VERSION=1.12@1.15.0
 RUN curl -sL \
   https://github.com/apache/openwhisk-runtime-go/archive/{$GO_PROXY_RELEASE_VERSION}.tar.gz\


### PR DESCRIPTION
Update the swift 4.2 and swift 5.1 runtime builds from golang:1.12 to golang:1.15, to continue to get security fixes for the generated proxy.