### PR TITLE
define GitHub action for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,117 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Continuous Integration
+
+on:
+  push:
+    branches: [ master ]
+    tags: [ '*' ]
+  pull_request:
+    branches: [ master ]
+    types: [ opened, synchronize, reopened ]
+  schedule:
+    - cron: '30 1 * * 1,3,5'
+
+permissions: read-all
+
+jobs:
+  ci:
+    runs-on: ubuntu-22.04
+    env:
+      PUSH_NIGHTLY: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/master' }}
+      PUSH_RELEASE: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+    steps:
+      # Checkout just this repo and run scanCode before we do anything else
+      - name: Checkout runtime repo
+        uses: actions/checkout@v3
+        with:
+          path: runtime
+      - name: Scan Code
+        uses: apache/openwhisk-utilities/scancode@master
+
+      # Install core OpenWhisk artifacts needed to build/test anything else
+      - name: Checkout OpenWhisk core repo
+        uses: actions/checkout@v3
+        with:
+          repository: apache/openwhisk
+          path: core
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - name: Compile and Install Core OpenWhisk
+        working-directory: core
+        run: |
+          ./gradlew :tests:compileTestScala
+          ./gradlew install
+
+      # Build this repository
+      - name: Build Runtime
+        working-directory: runtime
+        run: |
+          ./gradlew distDocker
+
+      # Compile test files using images built in Build Runtime step
+      - name: Compile test files
+        working-directory: runtime/tests/dat
+        run: ./build.sh
+
+      # Test this repository
+      - name: Test Runtime
+        working-directory: runtime
+        env:
+          OPENWHISK_HOME: ${{ github.workspace }}/core
+        run: |
+          ./gradlew :tests:checkScalafmtAll
+          ./gradlew :tests:testRuntime
+
+      # Conditionally publish runtime images to DockerHub
+      # Important: naming convention for release tags is runtime@version
+      - name: Docker Login
+        if: ${{ env.PUSH_NIGHTLY  == 'true' || env.PUSH_RELEASE == 'true' }}
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USER_OPENWHISK }}
+          password: ${{ secrets.DOCKERHUB_TOKEN_OPENWHISK }}
+      - name: Push Nightly Images
+        if: ${{ env.PUSH_NIGHTLY  == 'true' }}
+        working-directory: runtime
+        run: |
+          SHORT_COMMIT=$(git rev-parse --short "$GITHUB_SHA")
+          ./gradlew :core:swift51Action:distDocker -PdockerRegistry=docker.io -PdockerImagePrefix=openwhisk -PdockerImageTag=nightly
+          ./gradlew :core:swift51Action:distDocker -PdockerRegistry=docker.io -PdockerImagePrefix=openwhisk -PdockerImageTag=$SHORT_COMMIT
+          ./gradlew :core:swift53Action:distDocker -PdockerRegistry=docker.io -PdockerImagePrefix=openwhisk -PdockerImageTag=nightly
+          ./gradlew :core:swift53Action:distDocker -PdockerRegistry=docker.io -PdockerImagePrefix=openwhisk -PdockerImageTag=$SHORT_COMMIT
+          ./gradlew :core:swift54Action:distDocker -PdockerRegistry=docker.io -PdockerImagePrefix=openwhisk -PdockerImageTag=nightly
+          ./gradlew :core:swift54Action:distDocker -PdockerRegistry=docker.io -PdockerImagePrefix=openwhisk -PdockerImageTag=$SHORT_COMMIT
+      - name: Push Release Images
+        if: ${{ env.PUSH_RELEASE == 'true' }}
+        working-directory: runtime
+        run: |
+          RUNTIME_VERSION=${GITHUB_REF_NAME%@*}
+          IMAGE_TAG=${GITHUB_REF_NAME##*@}
+          if [ ${RUNTIME_VERSION} == "5.1" ]; then
+            RUNTIME="swift51Action"
+          elif [ ${RUNTIME_VERSION} == "5.3" ]; then
+            RUNTIME="swift53Action"
+          elif [ ${RUNTIME_VERSION} == "5.4" ]; then
+            RUNTIME="swift54Action"
+          fi
+          ./gradlew :core:$RUNTIME:distDocker -PdockerRegistry=docker.io -PdockerImagePrefix=openwhisk -PdockerImageTag=$IMAGE_TAG

--- a/ansible/files/runtimes.json
+++ b/ansible/files/runtimes.json
@@ -15,11 +15,11 @@
   "runtimes": {
     "nodejs": [
       {
-        "kind": "nodejs:10",
+        "kind": "nodejs:14",
         "default": true,
         "image": {
           "prefix": "openwhisk",
-          "name": "action-nodejs-v10",
+          "name": "action-nodejs-v14",
           "tag": "nightly"
         },
         "deprecated": false,

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -52,3 +52,13 @@ dependencies {
 tasks.withType(ScalaCompile) {
     scalaCompileOptions.additionalParameters = gradle.scala.compileFlags
 }
+
+task testRuntime(type: Test) {
+    include "runtime/actionContainers/**"
+    exclude "runtime/sdk/**"
+}
+
+task testSDK(type: Test) {
+    include "runtime/sdk/**"
+    exclude "runtime/actionContainers/**"
+}


### PR DESCRIPTION
I've had no luck trying to get the SDK portion of the tests working, so this PR just sets up basic CI for the runtime itself so we can resume pushing nightly images to dockerhub (and be in a position to get a release out the door). 

If we really want to maintain the Swift SDK going forward, we'll need to get the SDK tests working in CI.  The alternative would be to deprecate the Swift SDK and remove it entirely.  Defer that decision to later...
